### PR TITLE
Use internal handles for process management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,14 @@ all-features = true
 
 [features]
 default = ["backtrace"]
-pool = ["libc"]
 test-support = ["ctor"]
 
 [dependencies]
 ipc-channel = "0.13.0"
 serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
-libc = { version = "0.2.66", optional = true }
+libc = "0.2.66"
 ctor = { version = "0.1.12", optional = true }
-
-[[example]]
-name = "pool"
-required-features = ["pool"]
 
 [[example]]
 name = "panic"
@@ -41,4 +36,4 @@ required-features = ["test-support"]
 
 [[test]]
 name = "test_pool"
-required-features = ["test-support", "pool"]
+required-features = ["test-support"]

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ checkall:
 
 testall:
 	cargo check --no-default-features --all
-	cargo check --no-default-features --features pool --all
 	cargo check --no-default-features --features test-support --all
 	cargo test --all-features --all
 	cargo run --all-features --example join

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The following feature flags exist:
 * `backtrace`: this feature is enabled by default.  When in use then
   backtraces are captured with the `backtrace-rs` crate and serialized
   across process boundaries.
-* `pool`: enables the pool support.
 * `test-support`: when this feature is enabled procspawn can be used
   with rusttest.  See [`enable_test_support!`](https://docs.rs/procspawn/latest/procspawn/macro.enable_test_support.html)
   for more information.

--- a/examples/kill.rs
+++ b/examples/kill.rs
@@ -3,6 +3,6 @@ use procspawn::{self, spawn};
 #[allow(clippy::empty_loop)]
 fn main() {
     procspawn::init();
-    let handle = spawn((), |()| loop {});
+    let mut handle = spawn((), |()| loop {});
     handle.kill().unwrap();
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,7 +77,6 @@ enum SpawnErrorKind {
     Ipc(IpcError),
     Io(IoError),
     Panic(Panic),
-    #[cfg(feature = "pool")]
     Cancelled,
 }
 
@@ -91,7 +90,6 @@ impl SpawnError {
         }
     }
 
-    #[cfg(feature = "pool")]
     pub(crate) fn new_cancelled() -> SpawnError {
         SpawnError {
             kind: SpawnErrorKind::Cancelled,
@@ -105,7 +103,6 @@ impl std::error::Error for SpawnError {
             SpawnErrorKind::Ipc(ref err) => Some(&*err),
             SpawnErrorKind::Io(ref err) => Some(&*err),
             SpawnErrorKind::Panic(_) => None,
-            #[cfg(feature = "pool")]
             SpawnErrorKind::Cancelled => None,
         }
     }
@@ -117,7 +114,6 @@ impl fmt::Display for SpawnError {
             SpawnErrorKind::Ipc(_) => write!(f, "process spawn error: ipc error"),
             SpawnErrorKind::Io(_) => write!(f, "process spawn error: i/o error"),
             SpawnErrorKind::Panic(ref p) => write!(f, "process spawn error: panic: {}", p),
-            #[cfg(feature = "pool")]
             SpawnErrorKind::Cancelled => write!(f, "process spawn error: call cancelled"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ pub mod testsupport;
 
 pub use self::core::{init, ProcConfig};
 pub use self::error::{Panic, SpawnError};
-pub use self::proc::{Builder, JoinHandle};
 pub use self::pool::{Pool, PoolBuilder};
+pub use self::proc::{Builder, JoinHandle};
 
 /// Spawn a new process to run a function with some payload.
 pub fn spawn<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@
 //! * `backtrace`: this feature is enabled by default.  When in use then
 //!   backtraces are captured with the `backtrace-rs` crate and serialized
 //!   across process boundaries.
-//! * `pool`: enables the pool support.
 //! * `test-support`: when this feature is enabled procspawn can be used
 //!   with rusttest.  See [`enable_test_support!`](macro.enable_test_support.html)
 //!   for more information.
@@ -66,7 +65,6 @@ pub mod testsupport;
 pub use self::core::{init, ProcConfig};
 pub use self::error::{Panic, SpawnError};
 pub use self::proc::{Builder, JoinHandle};
-
 pub use self::pool::{Pool, PoolBuilder};
 
 /// Spawn a new process to run a function with some payload.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ pub use self::core::{init, ProcConfig};
 pub use self::error::{Panic, SpawnError};
 pub use self::proc::{Builder, JoinHandle};
 
-#[cfg(feature = "pool")]
 pub use self::pool::{Pool, PoolBuilder};
 
 /// Spawn a new process to run a function with some payload.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,6 @@
-#![cfg(feature = "pool")]
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
+use std::io;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread;
@@ -10,31 +10,42 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::MarshalledCall;
 use crate::error::SpawnError;
-use crate::proc::{Builder, JoinHandle, JoinHandleInner};
+use crate::proc::{Builder, JoinHandle, JoinHandleInner, ProcessHandleState};
 
 type WaitFunc = Box<dyn FnOnce() -> bool + Send>;
 type NotifyErrorFunc = Box<dyn FnMut(SpawnError) + Send>;
 
-pub struct ScheduledTask {
-    cancelled: AtomicBool,
-    process: AtomicUsize,
+pub struct PooledHandleState {
+    pub cancelled: AtomicBool,
+    pub process_handle_state: Mutex<Option<Arc<ProcessHandleState>>>,
 }
 
-impl ScheduledTask {
-    pub fn pid(&self) -> Option<u32> {
-        match self.process.load(Ordering::SeqCst) {
-            0 => None,
-            x => Some(x as u32),
+impl PooledHandleState {
+    pub fn kill(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        if let Some(ref process_handle_state) = *self.process_handle_state.lock().unwrap() {
+            process_handle_state.kill();
+        }
+    }
+}
+
+pub struct PooledHandle<T> {
+    waiter_rx: mpsc::Receiver<Result<T, SpawnError>>,
+    shared: Arc<PooledHandleState>,
+}
+
+impl<T: Serialize + for<'de> Deserialize<'de>> PooledHandle<T> {
+    pub fn join(&mut self) -> Result<T, SpawnError> {
+        match self.waiter_rx.recv() {
+            Ok(Ok(rv)) => Ok(rv),
+            Ok(Err(err)) => Err(err),
+            Err(..) => Err(io::Error::new(io::ErrorKind::BrokenPipe, "process went away").into()),
         }
     }
 
-    pub fn kill(&self) {
-        self.cancelled.store(true, Ordering::SeqCst);
-        if let Some(pid) = self.pid() {
-            unsafe {
-                libc::kill(pid as i32, libc::SIGKILL);
-            }
-        }
+    pub fn kill(&mut self) -> Result<(), SpawnError> {
+        self.shared.kill();
+        Ok(())
     }
 }
 
@@ -53,7 +64,7 @@ impl ScheduledTask {
 pub struct Pool {
     sender: mpsc::Sender<(
         MarshalledCall,
-        Arc<ScheduledTask>,
+        Arc<PooledHandleState>,
         WaitFunc,
         NotifyErrorFunc,
     )>,
@@ -91,15 +102,15 @@ impl Pool {
         let error_waiter_tx = waiter_tx.clone();
         self.shared.queued_count.fetch_add(1, Ordering::SeqCst);
 
-        let task = Arc::new(ScheduledTask {
+        let shared = Arc::new(PooledHandleState {
             cancelled: AtomicBool::new(false),
-            process: AtomicUsize::new(0),
+            process_handle_state: Mutex::new(None),
         });
 
         self.sender
             .send((
                 call,
-                task.clone(),
+                shared.clone(),
                 Box::new(move || {
                     if let Ok(rv) = return_rx.recv() {
                         waiter_tx.send(rv.map_err(Into::into)).is_ok()
@@ -114,7 +125,7 @@ impl Pool {
             .ok();
 
         JoinHandle {
-            inner: Ok(JoinHandleInner::Pooled { waiter_rx, task }),
+            inner: Ok(JoinHandleInner::Pooled(PooledHandle { waiter_rx, shared })),
         }
     }
 
@@ -161,7 +172,7 @@ impl Pool {
         }
         self.shared.dead.store(true, Ordering::SeqCst);
         for monitor in self.shared.monitors.lock().unwrap().iter_mut() {
-            if let Some(join_handle) = monitor.join_handle.lock().unwrap().take() {
+            if let Some(mut join_handle) = monitor.join_handle.lock().unwrap().take() {
                 join_handle.kill().ok();
             }
         }
@@ -277,7 +288,7 @@ struct PoolShared {
     call_receiver: Mutex<
         mpsc::Receiver<(
             MarshalledCall,
-            Arc<ScheduledTask>,
+            Arc<PooledHandleState>,
             WaitFunc,
             NotifyErrorFunc,
         )>,
@@ -370,7 +381,7 @@ fn spawn_worker(
                     break;
                 }
 
-                let (call, scheduled_task, wait_func, mut err_func) = {
+                let (call, state, wait_func, mut err_func) = {
                     // Only lock jobs for the time it takes
                     // to get a job, not run it.
                     let lock = shared
@@ -387,13 +398,12 @@ fn spawn_worker(
                 shared.queued_count.fetch_sub(1, Ordering::SeqCst);
 
                 // this task was already cancelled, no need to execute it
-                if scheduled_task.cancelled.load(Ordering::SeqCst) {
+                if state.cancelled.load(Ordering::SeqCst) {
                     err_func(SpawnError::new_cancelled());
                 } else {
                     if let Some(ref mut handle) = *join_handle.lock().unwrap() {
-                        scheduled_task
-                            .process
-                            .store(handle.pid().unwrap_or(0) as usize, Ordering::SeqCst);
+                        *state.process_handle_state.lock().unwrap() =
+                            handle.process_handle_state().cloned();
                     }
 
                     let mut restart = false;
@@ -410,6 +420,8 @@ fn spawn_worker(
                             restart = true;
                         }
                     }
+
+                    *state.process_handle_state.lock().unwrap() = None;
 
                     if !restart && !wait_func() {
                         restart = true;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -26,7 +26,7 @@ fn test_panic() {
 
 #[test]
 fn test_kill() {
-    let handle = spawn((), |()| {
+    let mut handle = spawn((), |()| {
         thread::sleep(Duration::from_secs(10));
     });
     handle.kill().unwrap();

--- a/tests/test_pool.rs
+++ b/tests/test_pool.rs
@@ -37,6 +37,7 @@ fn test_basic() {
 fn test_overload() {
     let pool = Pool::new(2).unwrap();
     let mut handles = vec![];
+    let mut with_pid = 0;
 
     for _ in 0..10 {
         handles.push(pool.spawn((), |()| {
@@ -45,9 +46,13 @@ fn test_overload() {
     }
 
     thread::sleep(Duration::from_millis(100));
-    for (idx, handle) in handles.iter().enumerate() {
-        assert_eq!(handle.pid().is_some(), idx < 2);
+    for handle in handles.iter() {
+        if handle.pid().is_some() {
+            with_pid += 1;
+        }
     }
+
+    assert_eq!(with_pid, 2);
 
     // kill the pool
     pool.kill();


### PR DESCRIPTION
This is a slightly ugly way to manage processes internally and should fix #7 

This also removes the pool feature flag again.