### PR TITLE
Experimental support for catching serialization errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [features]
 default = ["backtrace"]
+json = ["serde_json"]
 test-support = ["ctor"]
 
 [dependencies]
@@ -25,10 +26,15 @@ serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
 libc = "0.2.66"
 ctor = { version = "0.1.12", optional = true }
+serde_json = { version = "1.0.47", optional = true }
 
 [[example]]
 name = "panic"
 required-features = ["backtrace"]
+
+[[example]]
+name = "bad-serialization"
+required-features = ["json"]
 
 [[test]]
 name = "test_basic"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ testall:
 	cargo run --all-features --example simple
 	cargo run --all-features --example stdout
 	cargo run --all-features --example timeout
+	cargo run --all-features --example bad-serialization
 	cargo run --all-features --example args -- 1 2 3
 .PHONY: testall
 

--- a/examples/bad-serialization.rs
+++ b/examples/bad-serialization.rs
@@ -1,0 +1,31 @@
+use procspawn::{self, spawn, Json};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct InnerStruct {
+    value: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct BadStruct {
+    #[serde(flatten)]
+    inner: InnerStruct,
+}
+
+fn main() {
+    procspawn::init();
+
+    // json works:
+    let handle = spawn((), |()| {
+        Json(BadStruct {
+            inner: InnerStruct { value: 42 },
+        })
+    });
+    println!("result with JSON: {:?}", handle.join());
+
+    // bincode fails:
+    let handle = spawn((), |()| BadStruct {
+        inner: InnerStruct { value: 42 },
+    });
+    println!("result with bincode: {:?}", handle.join());
+}

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,39 @@
+use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
+use serde::ser::{self, Serialize, Serializer};
+
+/// Utility wrapper to force values through JSON serialization.
+///
+/// By default `procspawn` will use [`bincode`](https://github.com/servo/bincode) to serialize
+/// data across process boundaries.  This has some limitations which can cause serialization
+/// or deserialization to fail for some types.
+///
+/// Since JSON is generally better supported in the serde ecosystem this lets you work
+/// around some known bugs.
+///
+/// * serde flatten not being supported: [bincode#245](https://github.com/servo/bincode/issues/245)
+/// * vectors with unknown length not supported: [bincode#167](https://github.com/servo/bincode/issues/167)
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Json<T>(pub T);
+
+impl<T: Serialize> Serialize for Json<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let json = serde_json::to_string(&self.0).map_err(|e| ser::Error::custom(e.to_string()))?;
+        serializer.serialize_str(&json)
+    }
+}
+
+impl<'de, T: DeserializeOwned> Deserialize<'de> for Json<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Json<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json =
+            String::deserialize(deserializer).map_err(|e| de::Error::custom(e.to_string()))?;
+        Ok(Json(
+            serde_json::from_str(&json).map_err(|e| de::Error::custom(e.to_string()))?,
+        ))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ mod error;
 mod panic;
 mod pool;
 
+#[cfg(feature = "json")]
+mod json;
+
 #[doc(hidden)]
 pub mod testsupport;
 
@@ -68,6 +71,9 @@ pub use self::core::{init, ProcConfig};
 pub use self::error::{Location, PanicInfo, SpawnError};
 pub use self::pool::{Pool, PoolBuilder};
 pub use self::proc::{Builder, JoinHandle};
+
+#[cfg(feature = "json")]
+pub use self::json::Json;
 
 /// Spawn a new process to run a function with some payload.
 pub fn spawn<


### PR DESCRIPTION
This tries to catch serialization errors and report them across the process boundary. This seems quite insane because it calls `send()` twice. I'm also currently experiencing all kinds of errors being reported on my mac but I'm not sure if this is related to this change.

This also adds a JSON wrapper so that bincode incompatible values can be send across.

Opened an upstream issue in ipc-channel: https://github.com/servo/ipc-channel/issues/257