### PR TITLE
Added JSON wrapper and better communicate serialization errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 [features]
 default = ["backtrace"]
 test-support = ["ctor"]
+json = ["serde_json"]
 
 [dependencies]
 ipc-channel = "0.13.0"
@@ -25,10 +26,15 @@ serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
 libc = "0.2.66"
 ctor = { version = "0.1.12", optional = true }
+serde_json = { version = "1.0.47", optional = true }
 
 [[example]]
 name = "panic"
 required-features = ["backtrace"]
+
+[[example]]
+name = "bad-serialization"
+required-features = ["backtrace", "json"]
 
 [[test]]
 name = "test_basic"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ testall:
 	cargo run --all-features --example simple
 	cargo run --all-features --example stdout
 	cargo run --all-features --example timeout
+	cargo run --all-features --example bad-serialization
 	cargo run --all-features --example args -- 1 2 3
 .PHONY: testall
 

--- a/examples/bad-serialization.rs
+++ b/examples/bad-serialization.rs
@@ -1,0 +1,33 @@
+use procspawn::{self, spawn, Json};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct InnerStruct {
+    value: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct BadStruct {
+    #[serde(flatten)]
+    inner: InnerStruct,
+}
+
+fn main() {
+    procspawn::init();
+
+    // json works:
+    println!("JSON lets you send a flattened object through:");
+    let handle = spawn((), |()| {
+        Json(BadStruct {
+            inner: InnerStruct { value: 42 },
+        })
+    });
+    println!("result with JSON: {:?}", handle.join());
+
+    println!("raw bincode currently does not permit this:");
+    // bincode fails:
+    let handle = spawn((), |()| BadStruct {
+        inner: InnerStruct { value: 42 },
+    });
+    println!("result with bincode: {:?}", handle.join());
+}

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,64 @@
+use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
+use serde::ser::{self, Serialize, Serializer};
+
+/// Utility wrapper to force values through JSON serialization.
+///
+/// By default `procspawn` will use [`bincode`](https://github.com/servo/bincode) to serialize
+/// data across process boundaries.  This has some limitations which can cause serialization
+/// or deserialization to fail for some types.
+///
+/// Since JSON is generally better supported in the serde ecosystem this lets you work
+/// around some known bugs.
+///
+/// * serde flatten not being supported: [bincode#245](https://github.com/servo/bincode/issues/245)
+/// * vectors with unknown length not supported: [bincode#167](https://github.com/servo/bincode/issues/167)
+///
+/// Examples:
+///
+/// ```rust,no_run
+/// use procspawn::{spawn, Json};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Serialize, Deserialize, Debug)]
+/// struct InnerStruct {
+///     value: u64,
+/// }
+///
+/// #[derive(Serialize, Deserialize, Debug)]
+/// struct BadStruct {
+///     #[serde(flatten)]
+///     inner: InnerStruct,
+/// }
+///
+/// let handle = spawn((), |()| {
+///     Json(BadStruct {
+///         inner: InnerStruct { value: 42 },
+///     })
+/// });
+/// let value = handle.join().unwrap().0;
+/// ```
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Json<T>(pub T);
+
+impl<T: Serialize> Serialize for Json<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let json = serde_json::to_string(&self.0).map_err(|e| ser::Error::custom(e.to_string()))?;
+        serializer.serialize_str(&json)
+    }
+}
+
+impl<'de, T: DeserializeOwned> Deserialize<'de> for Json<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Json<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json =
+            String::deserialize(deserializer).map_err(|e| de::Error::custom(e.to_string()))?;
+        Ok(Json(
+            serde_json::from_str(&json).map_err(|e| de::Error::custom(e.to_string()))?,
+        ))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,17 @@
 //! * `test-support`: when this feature is enabled procspawn can be used
 //!   with rusttest.  See [`enable_test_support!`](macro.enable_test_support.html)
 //!   for more information.
+//! * `json`: enables optional JSON serialization.  For more information see
+//!   [Bincode Limitations](#bincode-limitations).
+//!
+//! ## Bincode Limitations
+//!
+//! This crate uses [`bincode`](https://github.com/servo/bincode) internally
+//! for inter process communication.  Bincode currently has some limitations
+//! which make some serde features incompatible with it.  Most notably if you
+//! use `#[serde(flatten)]` data cannot be sent across the processes.  To
+//! work around this you can enable the `json` feature and wrap affected objects
+//! in the [`Json`](struct.Json.html) wrapper to force JSON serialization.
 //!
 //! ## Platform Support
 //!
@@ -61,6 +72,9 @@ mod error;
 mod panic;
 mod pool;
 
+#[cfg(feature = "json")]
+mod json;
+
 #[doc(hidden)]
 pub mod testsupport;
 
@@ -68,6 +82,9 @@ pub use self::core::{init, ProcConfig};
 pub use self::error::{Location, PanicInfo, SpawnError};
 pub use self::pool::{Pool, PoolBuilder};
 pub use self::proc::{Builder, JoinHandle};
+
+#[cfg(feature = "json")]
+pub use self::json::Json;
 
 /// Spawn a new process to run a function with some payload.
 pub fn spawn<


### PR DESCRIPTION
This is an alternative to #15 which is saner to support. This also ignores some errors internally we want to treat as benign (such as disconnected remote).