### PR TITLE
Switch back to fn()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ autotests = true
 all-features = true
 
 [features]
-default = ["backtrace"]
+default = ["backtrace", "safe-shared-libraries"]
 test-support = ["ctor"]
 json = ["serde_json"]
+safe-shared-libraries = ["findshlibs"]
 
 [dependencies]
 ipc-channel = "0.13.0"
@@ -27,7 +28,7 @@ backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
 libc = "0.2.66"
 ctor = { version = "0.1.12", optional = true }
 serde_json = { version = "1.0.47", optional = true }
-findshlibs = "0.5.0"
+findshlibs = { version = "0.5.0", optional = true }
 
 [[example]]
 name = "panic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
 libc = "0.2.66"
 ctor = { version = "0.1.12", optional = true }
 serde_json = { version = "1.0.47", optional = true }
+findshlibs = "0.5.0"
 
 [[example]]
 name = "panic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,9 @@
 //! # Platform Support
 //!
 //! Currently this crate only supports macOS and Linux because ipc-channel
-//! itself does not support Windows yet.
+//! itself does not support Windows yet.  Additionally the findshlibs which is
+//! used for the `safe-shared-libraries` feature also does not yet support
+//! Windows.
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,10 @@
 //!
 //! The following feature flags exist:
 //!
+//! * `safe-shared-libraries`: this feature is enabled by default.  When this
+//!   feature is disable then no validation about shared library load status
+//!   is performed around IPC calls.  This is highly unsafe if shared libraries
+//!   are being used and a function from a shared library is spawned.
 //! * `backtrace`: this feature is enabled by default.  When in use then
 //!   backtraces are captured with the `backtrace-rs` crate and serialized
 //!   across process boundaries.
@@ -74,7 +78,13 @@
 //! `procspawn` uses the [`findshlibs`](https://github.com/gimli-rs/findshlibs)
 //! crate to determine where a function is located in memory in both processes.
 //! If a shared library is not loaded in the subprocess (because for instance it
-//! is loaded at runtime) then the call will fail.
+//! is loaded at runtime) then the call will fail.  Because this adds quite
+//! some overhead over every call you can also disable the `safe-shared-libraries`
+//! feature (which is on by default) in which case you are not allowed to
+//! invoke functions from shared libraries and no validation is performed.
+//!
+//! This in normal circumstances should be okay but technically disabling this
+//! feature is a violation to Rust's safety guarnatees!
 //!
 //! # Platform Support
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,13 @@
 //! work around this you can enable the `json` feature and wrap affected objects
 //! in the [`Json`](struct.Json.html) wrapper to force JSON serialization.
 //!
+//! # Shared Libraries
+//!
+//! `procspawn` uses the [`findshlibs`](https://github.com/gimli-rs/findshlibs)
+//! crate to determine where a function is located in memory in both processes.
+//! If a shared library is not loaded in the subprocess (because for instance it
+//! is loaded at runtime) then the call will fail.
+//!
 //! # Platform Support
 //!
 //! Currently this crate only supports macOS and Linux because ipc-channel

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,13 +127,9 @@ pub use self::json::Json;
 /// });
 /// let result = handle.join().unwrap();
 /// ```
-pub fn spawn<
-    F: FnOnce(A) -> R + Copy,
-    A: Serialize + for<'de> Deserialize<'de>,
-    R: Serialize + for<'de> Deserialize<'de>,
->(
+pub fn spawn<A: Serialize + for<'de> Deserialize<'de>, R: Serialize + for<'de> Deserialize<'de>>(
     args: A,
-    f: F,
+    f: fn(A) -> R,
 ) -> JoinHandle<R> {
     Builder::new().spawn(args, f)
 }


### PR DESCRIPTION
Going via `FnOnce` is not really any better than what we did before. Going to to back to `fn()` for now. Need to figure out that we're not working with any function pointers that are coming from elsewhere separately.

This now also uses findshlibs to locate in which shared library we're doing all this. The downside obviously is that calls are much more expensive now because we need to enumerate all shared libraries around both sides of the call.

Given what the library is supposed to be used for I believe this is a fair enough restriction.

Fixes #18