### PR TITLE
Add safety assertion for potentially unsafe spawning

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -36,7 +36,7 @@ static ALLOW_UNSAFE_SPAWN: AtomicBool = AtomicBool::new(false);
 ///
 /// You must only call this function if you can guarantee that none of your
 /// `spawn` calls cross a shared library boundary.
-pub unsafe fn assert_no_shared_libraries() {
+pub unsafe fn assert_spawn_is_safe() {
     #[cfg(not(feature = "safe-shared-libraries"))]
     {
         ALLOW_UNSAFE_SPAWN.store(true, Ordering::SeqCst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,9 @@
 //! feature (which is on by default) in which case you are not allowed to
 //! invoke functions from shared libraries and no validation is performed.
 //!
-//! This in normal circumstances should be okay but technically disabling this
-//! feature is a violation to Rust's safety guarnatees!
+//! This in normal circumstances should be okay but you need to validate this.
+//! Spawning processes will be disabled if the feature is not enabled until
+//! you call the [`assert_no_shared_libraries`](fn.assert_no_shared_libraries.html) function.
 //!
 //! # Platform Support
 //!
@@ -124,7 +125,7 @@ mod json;
 #[doc(hidden)]
 pub mod testsupport;
 
-pub use self::core::{init, ProcConfig};
+pub use self::core::{assert_no_shared_libraries, init, ProcConfig};
 pub use self::error::{Location, PanicInfo, SpawnError};
 pub use self::pool::{Pool, PoolBuilder};
 pub use self::proc::{Builder, JoinHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //!
 //! This in normal circumstances should be okay but you need to validate this.
 //! Spawning processes will be disabled if the feature is not enabled until
-//! you call the [`assert_no_shared_libraries`](fn.assert_no_shared_libraries.html) function.
+//! you call the [`assert_spawn_is_safe`](fn.assert_spawn_is_safe.html) function.
 //!
 //! # Platform Support
 //!
@@ -125,7 +125,7 @@ mod json;
 #[doc(hidden)]
 pub mod testsupport;
 
-pub use self::core::{assert_no_shared_libraries, init, ProcConfig};
+pub use self::core::{assert_spawn_is_safe, init, ProcConfig};
 pub use self::error::{Location, PanicInfo, SpawnError};
 pub use self::pool::{Pool, PoolBuilder};
 pub use self::proc::{Builder, JoinHandle};

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -13,7 +13,7 @@ use std::{io, thread};
 use ipc_channel::ipc::{self, IpcOneShotServer, IpcReceiver, IpcSender};
 use serde::{Deserialize, Serialize};
 
-use crate::core::{assert_initialized, should_pass_args, MarshalledCall, ENV_NAME};
+use crate::core::{assert_spawn_okay, should_pass_args, MarshalledCall, ENV_NAME};
 use crate::error::{PanicInfo, SpawnError};
 use crate::pool::PooledHandle;
 
@@ -205,7 +205,7 @@ impl Builder {
         args: A,
         func: fn(A) -> R,
     ) -> JoinHandle<R> {
-        assert_initialized();
+        assert_spawn_okay();
         JoinHandle {
             inner: mem::replace(self, Default::default()).spawn_helper(args, func),
         }


### PR DESCRIPTION
This ensures that you need to confirm that the gloves are off.