### PR TITLE
Improve test support slightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ checkall:
 testall:
 	cargo check --no-default-features --all
 	cargo check --no-default-features --features test-support --all
-	cargo test --all-features --all
+	cargo test --all-features --all -- -q
 	cargo run --all-features --example join
 	cargo run --all-features --example kill
 	cargo run --all-features --example panic

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@
 //!   backtraces are captured with the `backtrace-rs` crate and serialized
 //!   across process boundaries.
 //! * `test-support`: when this feature is enabled procspawn can be used
-//!   with rusttest.  See [`enable_test_support!`](macro.enable_test_support.html)
-//!   for more information.
+//!   with rusttest.  See [`testing`](#testing) for more information.
 //! * `json`: enables optional JSON serialization.  For more information see
 //!   [Bincode Limitations](#bincode-limitations).
 //!
@@ -72,6 +71,27 @@
 //! use `#[serde(flatten)]` data cannot be sent across the processes.  To
 //! work around this you can enable the `json` feature and wrap affected objects
 //! in the [`Json`](struct.Json.html) wrapper to force JSON serialization.
+//!
+//! # Testing
+//!
+//! Due to limitations of the rusttest testing system there are some
+//! restrictions to how this crate operates.  First of all you need to enable
+//! the `test-support` feature for `procspawn` to work with rusttest at all.
+//! Secondly your tests need to invoke the
+//! [`enable_test_support!`](macro.enable_test_support.html) macro once
+//! top-level.
+//!
+//! With this done the following behavior applies:
+//!
+//! * Tests behave as if `procspawn::init` was called (that means with the
+//!   default arguments).  Other configuration is not supported.
+//! * procspawn will register a dummy test (named `procspawn_test_helper`)
+//!   which doesn't do anything when called directly, but acts as the spawning
+//!   helper for all `spawn` calls.
+//! * stdout is silenced by default unless `--show-output` or `--nocapture`
+//!   is passed to tests.
+//! * when trying to spawn with intercepted `stdout` be aware that there is
+//!   extra noise that will be emitted by rusttest.
 //!
 //! # Shared Libraries
 //!


### PR DESCRIPTION
This change redirects stdout to `/dev/null` by default unless tests are invoked with `--show-output` or `--nocapture` to cut back on test noise.