### PR TITLE
Added macros for spawning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ testall:
 	cargo run --all-features --example stdout
 	cargo run --all-features --example timeout
 	cargo run --all-features --example async
+	cargo run --all-features --example macro
 	cargo run --all-features --example bad-serialization
 	cargo run --all-features --example args -- 1 2 3
 .PHONY: testall

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ With this done the following behavior applies:
 * when trying to spawn with intercepted `stdout` be aware that there is
   extra noise that will be emitted by rusttest.
 
-Example:
-
 ```rust
 procspawn::enable_test_support!();
 
@@ -151,6 +149,21 @@ however a few limitations / differences with async support currently:
 * when you drop a join handle the process is being terminated.
 * there is no native join with timeout support.  You can use your executors
   timeout functionality to achieve the same.
+
+## Macros
+
+Alternatively the [`spawn!`](https://docs.rs/procspawn/latest/procspawn/macro.spawn.html) macro can be used which can
+make passing more than one argument easier:
+
+```rust
+let a = 42u32;
+let b = 23u32;
+let c = 1;
+let handle = procspawn::spawn!((a => base, b, mut c) || -> Result<_, ()> {
+    c += 1;
+    Ok(base + b + c)
+});
+```
 
 ## Platform Support
 

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,0 +1,16 @@
+use procspawn::{self, spawn};
+
+fn main() {
+    procspawn::init();
+
+    let a = 42u32;
+    let b = 23u32;
+    let c = 1;
+    let handle = spawn!((a => new_name1, b, mut c) || -> Result<_, ()> {
+        c += 1;
+        Ok(new_name1 + b + c)
+    });
+    let value = handle.join().unwrap();
+
+    println!("{:?}", value);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,12 +147,12 @@
 //! * when you drop a join handle the process is being terminated.
 //! * there is no native join with timeout support.  You can use your executors
 //!   timeout functionality to achieve the same.
-//! 
+//!
 //! # Macros
-//! 
+//!
 //! Alternatively the [`spawn!`](macro.spawn.html) macro can be used which can
 //! make passing more than one argument easier:
-//! 
+//!
 //! ```rust,no_run
 //! let a = 42u32;
 //! let b = 23u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,6 @@
 //! * when trying to spawn with intercepted `stdout` be aware that there is
 //!   extra noise that will be emitted by rusttest.
 //!
-//! Example:
-//!
 //! ```rust,no_run
 //! procspawn::enable_test_support!();
 //!
@@ -149,6 +147,21 @@
 //! * when you drop a join handle the process is being terminated.
 //! * there is no native join with timeout support.  You can use your executors
 //!   timeout functionality to achieve the same.
+//! 
+//! # Macros
+//! 
+//! Alternatively the [`spawn!`](macro.spawn.html) macro can be used which can
+//! make passing more than one argument easier:
+//! 
+//! ```rust,no_run
+//! let a = 42u32;
+//! let b = 23u32;
+//! let c = 1;
+//! let handle = procspawn::spawn!((a => base, b, mut c) || -> Result<_, ()> {
+//!     c += 1;
+//!     Ok(base + b + c)
+//! });
+//! ```
 //!
 //! # Platform Support
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,8 @@
 //!   shows JSON based workarounds for bincode limitations.
 //! * [async.rs](https://github.com/mitsuhiko/procspawn/blob/master/examples/async.rs):
 //!   demonstrates async usage.
+//! * [macro.rs](https://github.com/mitsuhiko/procspawn/blob/master/examples/macro.rs):
+//!   demonstrates async usage.
 //!
 //! More examples can be found in the example folder: [examples](https://github.com/mitsuhiko/procspawn/tree/master/examples)
 
@@ -190,6 +192,8 @@ mod asyncsupport;
 
 #[doc(hidden)]
 pub mod testsupport;
+
+mod macros;
 
 pub use self::core::{assert_spawn_is_safe, init, ProcConfig};
 pub use self::error::{Location, PanicInfo, SpawnError};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,153 @@
+/// Utility macro to spawn functions.
+///
+/// Since a very common pattern is to pass multiple values to a spawned
+/// function by using tuples it can be cumbersome to repeat the arguments.
+/// This macro makes it possible to not repeat oneself.  The first argument
+/// to the macro is a tuple of the arguments to pass, the second argument
+/// is the closure that should be invoked.
+///
+/// For each argument the following expressions are possible:
+///
+/// * `ident`: uses the local variable `ident` unchanged.
+/// * `ident => other`: serializes `ident` and deserializes into `other`
+/// * `*ident`: alias for `*ident => ident`.
+/// * `mut ident`: alias for `ident => mut ident`.
+///
+/// Example:
+///
+/// ```rust,no_run
+/// let a = 42u32;
+/// let b = 23u32;
+/// let handle = procspawn::spawn!((a, mut b) || {
+///     b += 1;
+///     a + b
+/// });
+/// ```
+#[macro_export]
+macro_rules! spawn {
+    ($($args:tt)*) => { $crate::_spawn_impl!($crate::spawn, $($args)*) }
+}
+
+/// Utility macro to spawn async functions.
+///
+/// This works exactly like the [`spawn!`](macro.spawn.html) macro but instead
+/// will invoke [`spawn_async`](fn.spawn_async.html).
+#[macro_export]
+#[cfg(feature = "async")]
+macro_rules! spawn_async {
+    ($($args:tt)*) => { $crate::_spawn_impl!($crate::spawn_async, $($args)*) }
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _spawn_impl {
+    ($func:path, () || $($body:tt)*) => {
+        $func(
+            (),
+            |()|
+            $($body)*
+        )
+    };
+    ($func:path, ($($param:tt)*) || $($body:tt)*) => {
+        $func(
+            $crate::_spawn_call_arg!($($param)*),
+            |($crate::_spawn_decl_arg!($($param)*))|
+            $($body)*
+        )
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _spawn_call_arg {
+    ($expr:expr => mut $x:ident, $($tt:tt)*) => {(
+        $expr, $crate::_spawn_call_arg!($($tt)*)
+    )};
+    (*$expr:expr => $x:ident, $($tt:tt)*) => {(
+        *$expr, $crate::_spawn_call_arg!($($tt)*)
+    )};
+    ($expr:expr => $x:ident, $($tt:tt)*) => {(
+        $expr, $crate::_spawn_call_arg!($($tt)*)
+    )};
+    ($expr:expr => mut $x:ident) => {(
+        $expr,
+    )};
+    ($expr:expr => $x:ident) => {(
+        $expr,
+    )};
+    (mut $x:ident, $($tt:tt)*) => {(
+        $x, $crate::_spawn_call_arg!($($tt)*)
+    )};
+    (mut $x:ident) => {(
+        $x,
+    )};
+    (*$x:ident, $($tt:tt)*) => {(
+        *$x, $crate::_spawn_call_arg!($($tt)*)
+    )};
+    ($x:ident, $($tt:tt)*) => {(
+        $x, $crate::_spawn_call_arg!($($tt)*)
+    )};
+    (*$x:ident) => {(
+        *$x,
+    )};
+    ($x:ident) => {(
+        $x,
+    )};
+
+    ($unexpected:tt) => {
+        $crate::_spawn_unexpected($unexpected);
+    };
+    () => (())
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _spawn_decl_arg {
+    ($expr:expr => mut $x:ident, $($tt:tt)*) => {(
+        mut $x, $crate::_spawn_decl_arg!($($tt)*)
+    )};
+    (*$expr:expr => $x:ident, $($tt:tt)*) => {(
+        $x, $crate::_spawn_decl_arg!($($tt)*)
+    )};
+    ($expr:expr => $x:ident, $($tt:tt)*) => {(
+        $x, $crate::_spawn_decl_arg!($($tt)*)
+    )};
+    ($expr:expr => mut $x:ident) => {(
+        mut $x,
+    )};
+    (*$expr:expr => $x:ident) => {(
+        $x,
+    )};
+    ($expr:expr => $x:ident) => {(
+        $x,
+    )};
+    (mut $x:ident, $($tt:tt)*) => {(
+        mut $x, $crate::_spawn_decl_arg!($($tt)*)
+    )};
+    (mut $x:ident) => {(
+        mut $x,
+    )};
+    (*$x:ident, $($tt:tt)*) => {(
+        $x, $crate::_spawn_decl_arg!($($tt)*)
+    )};
+    ($x:ident, $($tt:tt)*) => {(
+        $x, $crate::_spawn_decl_arg!($($tt)*)
+    )};
+    (*$x:ident) => {(
+        $x,
+    )};
+    ($x:ident) => {(
+        $x,
+    )};
+
+    ($unexpected:tt) => {
+        $crate::_spawn_unexpected($unexpected);
+    };
+    () => ()
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _spawn_unexpected {
+    () => {};
+}

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -1,0 +1,120 @@
+use procspawn::{self, spawn};
+
+procspawn::enable_test_support!();
+
+#[test]
+fn test_macro_no_args() {
+    let handle = spawn!(() || false);
+    let value = handle.join().unwrap();
+    assert_eq!(value, false);
+}
+
+#[test]
+fn test_macro_single_arg() {
+    let value = 42u32;
+
+    let handle = spawn!((value) || value);
+    assert_eq!(handle.join().unwrap(), 42);
+
+    let handle = spawn!((value => new_name) || new_name);
+    assert_eq!(handle.join().unwrap(), 42);
+
+    let ref_value = &value;
+
+    let handle = spawn!((*ref_value) || ref_value);
+    assert_eq!(handle.join().unwrap(), 42);
+
+    let handle = spawn!((*ref_value => new_name) || new_name);
+    assert_eq!(handle.join().unwrap(), 42);
+
+    let handle = spawn!((mut value) || {
+        value += 1;
+        value
+    });
+    assert_eq!(handle.join().unwrap(), 43);
+
+    let handle = spawn!((value => mut new_name) || {
+        new_name += 1;
+        new_name
+    });
+    assert_eq!(handle.join().unwrap(), 43);
+}
+
+#[test]
+fn test_macro_two_args() {
+    let value1 = 42u32;
+    let value2 = 23u32;
+
+    let handle = spawn!((value1, value2) || value1 + value2);
+    assert_eq!(handle.join().unwrap(), 42 + 23);
+
+    let handle = spawn!((value1 => new_name1, value2) || new_name1 + value2);
+    assert_eq!(handle.join().unwrap(), 42 + 23);
+
+    let ref_value = &value1;
+
+    let handle = spawn!((*ref_value, value2) || ref_value + value2);
+    assert_eq!(handle.join().unwrap(), 42 + 23);
+
+    let handle = spawn!((*ref_value => new_name, value2) || new_name + value2);
+    assert_eq!(handle.join().unwrap(), 42 + 23);
+
+    let handle = spawn!((mut value1, value2) || {
+        value1 += 1;
+        value1 + value2
+    });
+    assert_eq!(handle.join().unwrap(), 43 + 23);
+
+    let handle = spawn!((value1 => mut new_name, value2) || {
+        new_name += 1;
+        new_name + value2
+    });
+    assert_eq!(handle.join().unwrap(), 43 + 23);
+}
+
+#[test]
+fn test_macro_three_args() {
+    let value1 = 42u32;
+    let value2 = 23u32;
+    let value3 = 99u32;
+
+    let handle = spawn!((value1, value2, value3) || value1 + value2 + value3);
+    assert_eq!(handle.join().unwrap(), 42 + 23 + 99);
+
+    let handle = spawn!((value1 => new_name1, value2, value3) || new_name1 + value2 + value3);
+    assert_eq!(handle.join().unwrap(), 42 + 23 + 99);
+
+    let ref_value = &value1;
+
+    let handle = spawn!((*ref_value, value2, value3) || ref_value + value2 + value3);
+    assert_eq!(handle.join().unwrap(), 42 + 23 + 99);
+
+    let handle = spawn!((*ref_value => new_name, value2, value3) || new_name + value2 + value3);
+    assert_eq!(handle.join().unwrap(), 42 + 23 + 99);
+
+    let handle = spawn!((mut value1, value2, value3) || {
+        value1 += 1;
+        value1 + value2 + value3
+    });
+    assert_eq!(handle.join().unwrap(), 43 + 23 + 99);
+
+    let handle = spawn!((value1 => mut new_name, value2, value3) || {
+        new_name += 1;
+        new_name + value2 + value3
+    });
+    assert_eq!(handle.join().unwrap(), 43 + 23 + 99);
+}
+
+#[test]
+fn test_macro_three_args_rv() {
+    let value1 = 42u32;
+    let value2 = 23u32;
+    let value3 = 99u32;
+
+    let handle =
+        spawn!((value1, value2, value3) || -> Option<_> { Some(value1 + value2 + value3) });
+    assert_eq!(handle.join().unwrap(), Some(42 + 23 + 99));
+
+    let handle = spawn!((value1 => new_name1, value2, value3) || -> Option<_> { Some(new_name1 + value2 + value3) });
+    assert_eq!(handle.join().unwrap(), Some(42 + 23 + 99));
+}


### PR DESCRIPTION
This lets one do things like this:

```rust
use procspawn::{self, spawn};

fn main() {
    procspawn::init();

    let a = 42u32;
    let b = 23u32;
    let c = 1;
    let handle = spawn!((a => new_name1, b, mut c) || -> Result<_, ()> {
        c += 1;
        Ok(new_name1 + b + c)
    });
    let value = handle.join().unwrap();

    println!("{:?}", value);
}
```