### PR TITLE
Fix CVE-2022-23639 vulnerability in crossbeam-utils dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ json = ["serde_json"]
 safe-shared-libraries = ["findshlibs"]
 
 [dependencies]
-ipc-channel = "0.15.0"
+ipc-channel = "0.16.0"
 serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
 libc = "0.2.66"


### PR DESCRIPTION
Please see the details in the issue [#43 ](https://github.com/mitsuhiko/procspawn/issues/43)

`procspawn` depends on `ipc-channel` crate version 0.15.0, which depends on `crossbeam-channel` version 0.4. `crossbeam-channel` depends on `crossbeam-utils` that contains [security vulnerability CVE-2022-23639](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23639) that affects all version of the crate prior to 0.8.7. 
This PR updates version of `ipc-channel` to 0.16.0 which uses newer versions of `crossbeam` dependencies with fixed vulnerability issue. 