### PR TITLE
Change `&(dyn Any + Send)` to `&dyn Any`.

### DIFF
--- a/src/panic.rs
+++ b/src/panic.rs
@@ -23,7 +23,7 @@ pub fn reset_panic_info() {
     });
 }
 
-pub fn take_panic(panic: &(dyn Any + Send + 'static)) -> PanicInfo {
+pub fn take_panic(panic: &dyn Any) -> PanicInfo {
     PANIC_INFO
         .with(|pi| pi.borrow_mut().take())
         .unwrap_or_else(move || serialize_panic(panic))
@@ -57,7 +57,7 @@ pub fn init_panic_hook(capture_backtraces: BacktraceCapture) {
     }));
 }
 
-fn serialize_panic(panic: &(dyn Any + Send + 'static)) -> PanicInfo {
+fn serialize_panic(panic: &dyn Any) -> PanicInfo {
     PanicInfo::new(match panic.downcast_ref::<&'static str>() {
         Some(s) => s,
         None => match panic.downcast_ref::<String>() {


### PR DESCRIPTION
This changes `&(dyn Any + Send)` to `&dyn Any`, because the `Send` trait is a useless restriction for references. (`&(dyn Any + Send)` implicitly converts to `&dyn Any`, but not the other way around.)

See https://github.com/rust-lang/rust/pull/110799