### PR TITLE
add a way to join_timeout without consuming the handle

### DIFF
--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 fn main() {
     procspawn::init();
 
-    let handle = spawn((), |()| {
+    let mut handle = spawn((), |()| {
         thread::sleep(Duration::from_secs(10));
     });
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,7 @@ enum SpawnErrorKind {
     IpcChannelClosed(io::Error),
     Cancelled,
     TimedOut,
+    Consumed,
 }
 
 impl SpawnError {
@@ -178,6 +179,10 @@ impl SpawnError {
             kind: SpawnErrorKind::TimedOut,
         }
     }
+
+    pub(crate) fn new_consumed() -> SpawnError {
+        SpawnError { kind: SpawnErrorKind::Consumed }
+    }
 }
 
 impl std::error::Error for SpawnError {
@@ -188,6 +193,7 @@ impl std::error::Error for SpawnError {
             SpawnErrorKind::Panic(_) => None,
             SpawnErrorKind::Cancelled => None,
             SpawnErrorKind::TimedOut => None,
+            SpawnErrorKind::Consumed => None,
             SpawnErrorKind::IpcChannelClosed(ref err) => Some(err),
         }
     }
@@ -201,6 +207,7 @@ impl fmt::Display for SpawnError {
             SpawnErrorKind::Panic(ref p) => write!(f, "process spawn error: panic: {}", p),
             SpawnErrorKind::Cancelled => write!(f, "process spawn error: call cancelled"),
             SpawnErrorKind::TimedOut => write!(f, "process spawn error: timed out"),
+            SpawnErrorKind::Consumed => write!(f, "process spawn error: result already consumed"),
             SpawnErrorKind::IpcChannelClosed(_) => write!(
                 f,
                 "process spawn error: remote side closed (might have panicked on serialization)"

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -73,14 +73,14 @@ fn test_nested() {
 
 #[test]
 fn test_timeout() {
-    let handle = spawn((), |()| {
+    let mut handle = spawn((), |()| {
         thread::sleep(Duration::from_secs(10));
     });
 
     let err = handle.join_timeout(Duration::from_millis(100)).unwrap_err();
     assert!(err.is_timeout());
 
-    let handle = spawn((), |()| {
+    let mut handle = spawn((), |()| {
         thread::sleep(Duration::from_millis(100));
         42
     });

--- a/tests/test_pool.rs
+++ b/tests/test_pool.rs
@@ -21,7 +21,7 @@ fn test_basic() {
 
     let mut ok = 0;
     let mut failed = 0;
-    for handle in handles {
+    for mut handle in handles {
         if handle.join_timeout(Duration::from_secs(5)).is_ok() {
             ok += 1;
         } else {
@@ -62,14 +62,14 @@ fn test_overload() {
 fn test_timeout() {
     let pool = Pool::new(2).unwrap();
 
-    let handle = pool.spawn((), |()| {
+    let mut handle = pool.spawn((), |()| {
         thread::sleep(Duration::from_secs(10));
     });
 
     let err = handle.join_timeout(Duration::from_millis(100)).unwrap_err();
     assert!(err.is_timeout());
 
-    let handle = pool.spawn((), |()| {
+    let mut handle = pool.spawn((), |()| {
         thread::sleep(Duration::from_millis(100));
         42
     });


### PR DESCRIPTION
kind of weird API. one could also implement is_finished, but it would
have to take &mut self or use a cell internally
