### PR TITLE
chore: upgrade `ipc-channel` to version 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ json = ["serde_json"]
 safe-shared-libraries = ["findshlibs"]
 
 [dependencies]
-ipc-channel = "0.16.1"
+ipc-channel = "0.18.2"
 serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.43", optional = true, features = ["serde"] }
 libc = "0.2.66"


### PR DESCRIPTION
This updates a long tail of indirect dependencies, esp. `mio` to 1.0 which no longer uses the unmaintained `net2` crate.