### PR TITLE
Update `ipc-channel` and `windows-sys` crates and fix some lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ json = ["serde_json"]
 safe-shared-libraries = ["findshlibs"]
 
 [dependencies]
-ipc-channel = "0.18.2"
+ipc-channel = "0.19.0"
 serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.73", optional = true, features = ["serde"] }
 libc = "0.2.66"
@@ -35,7 +35,7 @@ findshlibs = { version = "0.10.2", optional = true }
 small_ctor = { version = "0.1.2", optional = true }
 
 [target."cfg(windows)".dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_System_Threading"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [[example]]
 name = "panic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,3 @@ pub use self::core::{assert_spawn_is_safe, init, ProcConfig};
 pub use self::error::{Location, PanicInfo, SpawnError};
 pub use self::pool::{Pool, PoolBuilder};
 pub use self::proc::{spawn, Builder, JoinHandle};
-
-#[cfg(feature = "async")]
-pub use self::asyncsupport::{spawn_async, AsyncJoinHandle};

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -29,6 +29,8 @@ pub fn take_panic(panic: &dyn Any) -> PanicInfo {
         .unwrap_or_else(move || serialize_panic(panic))
 }
 
+// PanicInfo is replaced by PanicHookInfo in 1.81 and deprecated in 1.82, but MSRV is 1.70
+#[allow(deprecated)]
 pub fn panic_handler(info: &panic::PanicInfo<'_>, capture_backtraces: BacktraceCapture) {
     PANIC_INFO.with(|pi| {
         #[allow(unused_mut)]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -61,7 +61,7 @@ impl fmt::Debug for Shmem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         struct ByteRepr<'a>(&'a Shmem);
 
-        impl<'a> fmt::Debug for ByteRepr<'a> {
+        impl fmt::Debug for ByteRepr<'_> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, "b\"")?;
                 for &byte in self.0.as_bytes() {


### PR DESCRIPTION
Removed some remains from the previously experimental async support, which were causing a clippy lint as the `async` feature flag doesn't exist.

Also added a missing `windows-sys` feature that was causing some compilation issues for me: https://github.com/dani-garcia/memsec/actions/runs/12869561710/job/35878649612#step:4:129
![image](https://github.com/user-attachments/assets/bd42df2e-0833-4a44-81f4-582216a6c114)

I've combined the crate updates and lints in one PR as the changes are fairly small but let me know if you prefer them split up.