### PR TITLE
upgrade dependency ipc-channel – fixes security advisory RUSTSEC-2025-0141

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,14 @@ jobs:
         run: make test
 
   build-stable:
-    name: Test on 1.70.0
+    name: Test on 1.86.0
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.70.0
+          toolchain: 1.86.0
           profile: minimal
           override: true
       - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ json = ["serde_json"]
 safe-shared-libraries = ["findshlibs"]
 
 [dependencies]
-ipc-channel = "0.18.2"
+ipc-channel = "0.22.0"
 serde = { version = "1.0.104", features = ["derive"] }
 backtrace = { version = "0.3.73", optional = true, features = ["serde"] }
 libc = "0.2.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["proc", "spawn", "subprocess"]
 readme = "README.md"
 autoexamples = true
 autotests = true
-rust-version = "1.70.0"
+rust-version = "1.86.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/core.rs
+++ b/src/core.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use findshlibs::{Avma, IterationControl, Segment, SharedLibrary};
 
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender, OpaqueIpcReceiver, OpaqueIpcSender};
-use ipc_channel::ErrorKind as IpcErrorKind;
+use ipc_channel::IpcError as IpcErrorKind;
 use serde::{Deserialize, Serialize};
 
 use crate::error::PanicInfo;
@@ -343,7 +343,7 @@ unsafe fn run_func<A, R>(
     // sending can fail easily because of bincode limitations.  If you see
     // this in your tracebacks consider using the `Json` wrapper.
     if let Err(err) = with_ipc_mode(|| sender.to().send(rv)) {
-        if let IpcErrorKind::Io(ref io) = *err {
+        if let IpcErrorKind::Io(ref io) = err {
             if io.kind() == io::ErrorKind::NotFound || io.kind() == io::ErrorKind::ConnectionReset {
                 // this error is okay.  this means nobody actually
                 // waited for the call, so we just ignore it.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::io;
 
-use ipc_channel::ipc::{IpcError, TryRecvError};
-use ipc_channel::{Error as BincodeError, ErrorKind as BincodeErrorKind};
+use ipc_channel::SerDeError as BincodeError;
+use ipc_channel::{IpcError, TryRecvError};
 use serde::{Deserialize, Serialize};
 
 /// Represents a panic caugh across processes.
@@ -159,6 +159,12 @@ impl SpawnError {
         matches!(self.kind, SpawnErrorKind::IpcChannelClosed(..))
     }
 
+    pub(crate) fn new_bincode(err: BincodeError) -> SpawnError {
+        SpawnError {
+            kind: SpawnErrorKind::Bincode(err),
+        }
+    }
+
     pub(crate) fn new_remote_close() -> SpawnError {
         SpawnError {
             kind: SpawnErrorKind::IpcChannelClosed(io::Error::new(
@@ -218,18 +224,6 @@ impl fmt::Display for SpawnError {
     }
 }
 
-impl From<BincodeError> for SpawnError {
-    fn from(err: BincodeError) -> SpawnError {
-        // unwrap nested IO errors
-        if let BincodeErrorKind::Io(io_err) = *err {
-            return SpawnError::from(io_err);
-        }
-        SpawnError {
-            kind: SpawnErrorKind::Bincode(err),
-        }
-    }
-}
-
 impl From<TryRecvError> for SpawnError {
     fn from(err: TryRecvError) -> SpawnError {
         match err {
@@ -243,8 +237,8 @@ impl From<IpcError> for SpawnError {
     fn from(err: IpcError) -> SpawnError {
         // unwrap nested IO errors
         match err {
+            IpcError::SerializationError(err) => SpawnError::new_bincode(err),
             IpcError::Io(err) => SpawnError::from(err),
-            IpcError::Bincode(err) => SpawnError::from(err),
             IpcError::Disconnected => SpawnError::new_remote_close(),
         }
     }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -355,8 +355,8 @@ pub struct ProcessHandle<T> {
     pub(crate) state: Arc<ProcessHandleState>,
 }
 
-fn is_ipc_timeout(err: &ipc_channel::ipc::TryRecvError) -> bool {
-    matches!(err, ipc_channel::ipc::TryRecvError::Empty)
+fn is_ipc_timeout(err: &ipc_channel::TryRecvError) -> bool {
+    matches!(err, ipc_channel::TryRecvError::Empty)
 }
 
 impl<T> ProcessHandle<T> {


### PR DESCRIPTION
This PR upgrades the `ipc-channel` dependency and thus fixes the security advisory [`RUSTSEC-2025-0141`](https://rustsec.org/advisories/RUSTSEC-2025-0141).

## To Do
This test fails:
```text
$ make test
[...]
thread 'main' panicked at /home/user/procspawn/src/core.rs:355:13:
could not send event over ipc channel: SerializationError(SerDeError(SerializeSeqLengthUnknown))
```
However, it also fails on `main`:
```text
$ make test
[...]
thread 'main' panicked at /home/user/procspawn/src/core.rs:352:13:
could not send event over ipc channel: SequenceMustHaveLength
```